### PR TITLE
Pre build sifis-xacml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - arm64
+      - pre-build-sifis-xacml
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,27 @@
 # syntax=docker/dockerfile:1
 FROM python:3.8
 
+# Install python packages
 COPY requirements.txt /
+RUN pip install --no-cache-dir -r /requirements.txt
+
+# Install jq
 RUN apt-get -y update && \
     apt-get -y install jq
 
+# Install Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
     echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
     
-
-RUN pip install --no-cache-dir -r /requirements.txt
-
+# Build sifis-xacml
+ADD sifis-xacml /sifis-xacml
+RUN cd sifis-xacml && \
+    cargo build && \
+    cd ..
 
 ADD application_manager /application_manager
-#ADD application_manager/*.py /
-#ADD application_manager/get-labels.sh /application_manager
 
 ADD run_application_manager/run_manager.sh /
-ADD sifis-xacml /sifis-xacml
 #ADD services/leader_file.txt /  uncomment this to test the run_manager
 
 RUN chmod +x /run_manager.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
 # Build sifis-xacml
 ADD sifis-xacml /sifis-xacml
 RUN cd sifis-xacml && \
-    cargo build && \
+    $HOME/.cargo/bin/cargo build && \
     cd ..
 
 ADD application_manager /application_manager

--- a/application_manager/app_dht.py
+++ b/application_manager/app_dht.py
@@ -5,7 +5,7 @@ import requests
 
 client = docker.from_env()
 
-api_url = "http://146.48.89.28:3000/"
+api_url = "http://localhost:3000/"
 
 
 def publish(ws, topic_uuid, requestor_id, request_id, containers):

--- a/application_manager/catch_topic.py
+++ b/application_manager/catch_topic.py
@@ -61,7 +61,7 @@ def notify_mobile_application(message):
             image_name + " " + message
         )  # The application can be installed
     print("[!] " + notification)
-    address = "http://146.48.89.28:3000/"
+    address = "http://localhost:3000/"
     notification_data = {
         "requestor_id": requestor_id,
         "request_id": request_id,
@@ -301,7 +301,7 @@ def on_open(ws):
 
 if __name__ == "__main__":
     ws = websocket.WebSocketApp(
-        "ws://146.48.89.28:3000/ws",
+        "ws://localhost:3000/ws",
         on_open=on_open,
         on_message=on_message,
         on_error=on_error,

--- a/application_manager/security_by_contract.py
+++ b/application_manager/security_by_contract.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import requests
 
 REGISTERED = False
-websocket_uri = "http://146.48.89.28:3000/"
+websocket_uri = "http://localhost:3000/"
 
 
 def get_json_register():


### PR DESCRIPTION
Avoid building the sifis-xacml package after the docker image is created. Therefore, avoid building at runtime.
This is an issue because the first time the `cargo run ...` command is invoked, it first builds sifis-xacml. Hence, this introduces a non-negligible delay in the "install" command that triggered the invocation of sifis-xacml.

With these changes, sifis-xacml is build when the docker image is created, and its binary is already stored in the image.

More:
Changed the DHT url to "localhost"