### PR TITLE
ci: Update the setup-python action

### DIFF
--- a/.github/workflows/application-manager.yml
+++ b/.github/workflows/application-manager.yml
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up last Python version
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: Install poetry
       run: |
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up last Python version
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
setup-python@v2 uses node12 that is going to disappear soon.